### PR TITLE
Add levenshtein distance err msgs for wrong paths 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "rss",
  "serde",
  "sqlx",
+ "str-distance",
  "tokio",
  "tracing",
  "tracing-actix-web",
@@ -2281,6 +2282,12 @@ dependencies = [
  "url",
  "uuid",
 ]
+
+[[package]]
+name = "str-distance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8416ac807fc3d3a155ac5e752e03b54c1e8cd1f1bc134959d41a3389aa01cf57"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ pretty_env_logger = "0.5.0"
 rss = { version = "2.0.6", features = ["atom", "validation", "serde", "with-serde"] }
 serde = { version = "1.0.188", features = ["derive"] }
 sqlx = { version = "0.7.1", features = ["time", "uuid", "tls-rustls", "runtime-tokio-rustls", "sqlite"] }
+str-distance = "0.1.0"
 tokio = {version = "1.32.0", features = ["full"]}
 tracing = "0.1.37"
 tracing-actix-web = "0.7.6"


### PR DESCRIPTION
Only provides one suggestion, but it works for misspellings and will tell you if you're using the wrong HTTP method.